### PR TITLE
refactor(gui): change gui & guiItem handlers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     compileOnly("com.dre.brewery:BreweryX:3.4.5-SNAPSHOT#4")
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("com.github.BreweryTeam:TheBrewingProject:v2.3.0")
+    compileOnly("net.kyori:adventure-text-minimessage:4.24.0")
     implementation("eu.okaeri:okaeri-configs-yaml-bukkit:5.0.8")
     implementation("com.zaxxer:HikariCP:7.0.2")
 }
@@ -36,6 +37,14 @@ dependencies {
 
 kotlin {
     jvmToolchain(21)
+}
+
+sourceSets {
+    main {
+        java {
+             srcDirs("src/main/kotlin")
+        }
+    }
 }
 
 

--- a/src/main/kotlin/dev/jsinco/recipes/configuration/RecipesTranslator.java
+++ b/src/main/kotlin/dev/jsinco/recipes/configuration/RecipesTranslator.java
@@ -7,13 +7,31 @@ import net.kyori.adventure.text.minimessage.translation.MiniMessageTranslator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
-import java.util.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
 
 //TODO make locale configurable /// placeholder
 

--- a/src/main/kotlin/dev/jsinco/recipes/gui/GuiItem.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/GuiItem.kt
@@ -1,10 +1,27 @@
 package dev.jsinco.recipes.gui
 
+import dev.jsinco.recipes.Recipes
+import dev.jsinco.recipes.util.ItemStackUtil
+import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
+import org.bukkit.persistence.PersistentDataType
 
-interface GuiItem {
+abstract class GuiItem {
 
-    fun createItem(): ItemStack?
+    companion object {
+        private val KEY = Recipes.key("gui_item_type")
+    }
 
-    fun type(): String
+    fun getItem(): ItemStack {
+        return ItemStackUtil.setPersistentData(createItem(), KEY, PersistentDataType.STRING, type())
+    }
+
+    fun type(): String {
+        // This could be set manually by child class instead
+        return this::class.java.simpleName.lowercase()
+    }
+
+    protected abstract fun createItem(): ItemStack
+
+    abstract fun handle(event: InventoryClickEvent, gui: RecipesGui)
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/NextPage.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/NextPage.kt
@@ -1,14 +1,16 @@
 package dev.jsinco.recipes.gui
 
 import org.bukkit.Material
+import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
 
-object NextPage : GuiItem {
+object NextPage : GuiItem() {
+
     override fun createItem(): ItemStack {
         return ItemStack(Material.ARROW)
     }
 
-    override fun type(): String {
-        return "next_page"
+    override fun handle(event: InventoryClickEvent, gui: RecipesGui) {
+        gui.nextPage()
     }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/PreviousPage.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/PreviousPage.kt
@@ -1,14 +1,16 @@
 package dev.jsinco.recipes.gui
 
 import org.bukkit.Material
+import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
 
-object PreviousPage : GuiItem {
+object PreviousPage : GuiItem() {
+
     override fun createItem(): ItemStack {
         return ItemStack(Material.ARROW)
     }
 
-    override fun type(): String {
-        return "previous_page"
+    override fun handle(event: InventoryClickEvent, gui: RecipesGui) {
+        gui.previousPage()
     }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/RecipeItem.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/RecipeItem.kt
@@ -1,8 +1,17 @@
 package dev.jsinco.recipes.gui
 
-interface RecipeItem : GuiItem {
 
-    override fun type(): String {
-        return "recipe"
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
+
+// Constructor can be simplified to just include the recipe and then we make the
+// recipe item based on a certain template from config.
+class RecipeItem(val itemStack: ItemStack) : GuiItem() {
+    override fun createItem(): ItemStack {
+        return itemStack
+    }
+
+    override fun handle(event: InventoryClickEvent, gui: RecipesGui) {
+        // do nothing
     }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/RecipesGui.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/RecipesGui.kt
@@ -1,19 +1,23 @@
 package dev.jsinco.recipes.gui
 
-import dev.jsinco.recipes.gui.integration.GuiIntegration
-import dev.jsinco.recipes.listeners.GuiEventListener
+import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
-import org.bukkit.inventory.Inventory
-import org.bukkit.persistence.PersistentDataType
+import org.bukkit.inventory.InventoryHolder
+import org.bukkit.inventory.ItemStack
 
 class RecipesGui(
     private val player: Player,
-    private val recipeItems: List<GuiIntegration.RecipeItem>,
-    private val inventory: Inventory
-) {
+    private val recipeItems: List<RecipeItem>,
+    title: String = "Recipes",
+    size: Int = 54
+) : InventoryHolder {
 
-    private var page = 0
+    private val inventory = Bukkit.createInventory(this, size, Component.text(title))
+    private val renderedGuiItems = mutableSetOf<GuiItem>()
+
     private val maxPages = Math.ceilDiv(recipeItems.size, 9 * 4)
+    private var page = 0
 
     fun nextPage() {
         page = maxPages.coerceAtMost(page + 1)
@@ -31,27 +35,33 @@ class RecipesGui(
         val pageContentSize = inventory.size - 18
         val pages = Math.ceilDiv(recipes.size, pageContentSize)
         if (page < pages) {
-            render(NextPage, 6)
+            renderItem(NextPage, 6)
         }
         if (page > 0) {
-            render(PreviousPage, 4)
+            renderItem(PreviousPage, 4)
         }
         val startPageContentIndex = Math.floorDiv(recipes.size, pageContentSize) * recipes.size
         val recipesToRead = recipes.size - startPageContentIndex
         for (i in 0 until recipesToRead) {
-            render(recipes[i + startPageContentIndex], i + 9)
+            renderItem(recipes[i + startPageContentIndex], i + 9)
         }
     }
 
-    fun render(guiItem: GuiItem, position: Int) {
-        val item = guiItem.createItem() ?: return
-        item.editPersistentDataContainer { pdc ->
-            pdc.set(
-                GuiEventListener.GUI_TYPE,
-                PersistentDataType.STRING,
-                guiItem.type()
-            )
+    fun renderItem(guiItem: GuiItem, position: Int) {
+        val item = guiItem.getItem()
+        if (!renderedGuiItems.contains(guiItem)) {
+            renderedGuiItems.add(guiItem)
         }
         inventory.setItem(position, item)
     }
+
+    fun fromItemStack(itemStack: ItemStack): GuiItem? {
+        val guiItem = renderedGuiItems.find { it.getItem() == itemStack }
+        return guiItem
+    }
+
+    fun open() = open(player)
+    fun open(player: Player) = player.openInventory(inventory)
+
+    override fun getInventory() = inventory
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/integration/BreweryXRecipe.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/integration/BreweryXRecipe.kt
@@ -5,7 +5,7 @@ import org.bukkit.inventory.ItemStack
 
 object BreweryXRecipe : GuiIntegration {
 
-    override fun createItem(recipeView: RecipeView): ItemStack? {
+    override fun createItem(recipeView: RecipeView): ItemStack {
         TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/integration/GuiIntegration.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/integration/GuiIntegration.kt
@@ -1,17 +1,8 @@
 package dev.jsinco.recipes.gui.integration
 
 import dev.jsinco.recipes.core.RecipeView
-import dev.jsinco.recipes.gui.GuiItem
 import org.bukkit.inventory.ItemStack
 
 interface GuiIntegration {
     fun createItem(recipeView: RecipeView): ItemStack?
-
-    data class RecipeItem(val identifier: String, val itemStack: ItemStack) : GuiItem {
-        override fun createItem(): ItemStack? {
-            return itemStack
-        }
-
-        override fun type() = "recipe"
-    }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/util/ItemStackUtil.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/util/ItemStackUtil.kt
@@ -1,0 +1,27 @@
+package dev.jsinco.recipes.util
+
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
+import org.bukkit.persistence.PersistentDataType
+
+// may be removed
+object ItemStackUtil {
+
+
+    fun editMeta(itemStack: ItemStack, block: (meta: ItemMeta) -> Unit): ItemStack {
+        val meta = itemStack.itemMeta
+        block(meta)
+        itemStack.itemMeta = meta
+        return itemStack
+    }
+
+    fun <P, C : Any> setPersistentData(itemStack: ItemStack, key: NamespacedKey, type: PersistentDataType<P, C>, value: C): ItemStack {
+        return editMeta(itemStack) {
+            it.persistentDataContainer.set(key, type, value)
+        }
+    }
+
+    fun hasPersistentKey(itemStack: ItemStack, key: NamespacedKey): Boolean = itemStack.itemMeta.persistentDataContainer.has(key,)
+
+}


### PR DESCRIPTION
Removes the global gui map and replaces it with an InventoryHolder implementation. Moves the handler of each GuiItem from a switch statement to a class-specific implementation. Moves the RecipesTranslator from it's own Java package into the kotlin package with the rest of the classes in the project. A few other things too