### PR TITLE
Fix: Only migrate recipes when permission has been set

### DIFF
--- a/src/main/kotlin/dev/jsinco/recipes/listeners/MigrationListener.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/listeners/MigrationListener.kt
@@ -1,6 +1,7 @@
 package dev.jsinco.recipes.listeners
 
 import dev.jsinco.recipes.Recipes
+import net.kyori.adventure.util.TriState
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -28,7 +29,7 @@ class MigrationListener : Listener {
         if (!Recipes.recipesConfig.migrate) return
         for ((recipeId, recipe) in Recipes.recipes()) {
             val permission = permissionTemplate.replace("%recipe%", recipeId)
-            if (!event.player.hasPermission(permission)) continue
+            if (event.player.permissionValue(permission) != TriState.TRUE) continue
             Recipes.recipeViewManager.insertOrMergeView(
                 event.player.uniqueId,
                 recipe.generateCompletedView()


### PR DESCRIPTION
Fixes #12 