### PR TITLE
Fix brew notes disappearing shortly after relogging

### DIFF
--- a/src/main/kotlin/dev/jsinco/recipes/data/PersistencyLinkedCache.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/data/PersistencyLinkedCache.kt
@@ -3,8 +3,5 @@ package dev.jsinco.recipes.data
 import java.util.UUID
 
 interface PersistencyLinkedCache {
-
-    fun clearAll(playerUuid: UUID)
-
     fun initiateCacheFor(playerUuid: UUID)
 }

--- a/src/main/kotlin/dev/jsinco/recipes/gui/RecipeGuiItemCache.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/gui/RecipeGuiItemCache.kt
@@ -41,7 +41,7 @@ class RecipeGuiItemCache : PersistencyLinkedCache {
         adminCache.clear()
     }
 
-    override fun clearAll(playerUuid: UUID) {
+    fun clearAll(playerUuid: UUID) {
         playerCache.remove(playerUuid)
     }
 

--- a/src/main/kotlin/dev/jsinco/recipes/listeners/PlayerEventListener.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/listeners/PlayerEventListener.kt
@@ -1,6 +1,7 @@
 package dev.jsinco.recipes.listeners
 
 import com.destroystokyo.paper.profile.PlayerProfile
+import dev.jsinco.recipes.BreweryRecipes
 import dev.jsinco.recipes.data.PersistencyLinkedCache
 import dev.jsinco.recipes.recipe.RecipeViewManager.Companion.CACHE_LIFETIME
 import io.papermc.paper.connection.PlayerConfigurationConnection
@@ -32,6 +33,7 @@ class PlayerEventListener(
                 else -> null
             }
         profile?.id?.let { playerUuid ->
+            forRemoval.remove(playerUuid)
             persistencyLinkedCaches.forEach { it.initiateCacheFor(playerUuid) }
         }
     }
@@ -47,9 +49,6 @@ class PlayerEventListener(
                 .map { it.key }
         }
         toRemove.forEach(forRemoval::remove)
-        persistencyLinkedCaches.forEach()
-        {
-            toRemove.forEach(it::clearAll)
-        }
+        toRemove.forEach(BreweryRecipes.recipeGuiItemCache::clearAll)
     }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/recipe/RecipeCompletionManager.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/recipe/RecipeCompletionManager.kt
@@ -56,11 +56,6 @@ class RecipeCompletionManager(private val storageImpl: StorageImpl) : Persistenc
         BreweryRecipes.recipeGuiItemCache.clearAll(playerUuid)
     }
 
-    override fun clearAll(playerUuid: UUID) {
-        backing.remove(playerUuid)
-        BreweryRecipes.recipeGuiItemCache.clearAll(playerUuid)
-    }
-
     override fun initiateCacheFor(playerUuid: UUID) {
         storageImpl.completedRecipeSession()
             .selectRecipeCompletions(playerUuid)

--- a/src/main/kotlin/dev/jsinco/recipes/recipe/RecipeViewManager.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/recipe/RecipeViewManager.kt
@@ -79,7 +79,4 @@ class RecipeViewManager(private val storageImpl: StorageImpl) : PersistencyLinke
         BreweryRecipes.recipeGuiItemCache.clearAll(playerUuid)
     }
 
-    override fun clearAll(playerUuid: UUID) {
-        BreweryRecipes.recipeGuiItemCache.clearAll(playerUuid)
-    }
 }


### PR DESCRIPTION
- The player listener clears all caches 60 seconds after a player leaves. If a player rejoins before that time, the cache will still be cleared when 60 seconds expires.
- Each cache's `clearAll()` method clears the lazy GUI cache, but the recipe completion cache additionally clears the player's entry in the backing map. Since the recipe completion cache is loaded from the database on join, the cache will not be repopulated and brew notes disappear from the recipe book.