### PR TITLE
Only re-register recipes on reload if changes made

### DIFF
--- a/src/main/kotlin/dev/jsinco/recipes/BreweryRecipes.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/BreweryRecipes.kt
@@ -81,7 +81,7 @@ class BreweryRecipes : JavaPlugin() {
         lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS) {
             it.registrar().register(RecipesCommand.command())
         }
-        recipesConfig.book.craftingRecipe.register(BookUtil.createBook(), "recipes_book")
+        recipesConfig.book.craftingRecipe.register("recipes_book", BookUtil.createBook())
         spawnConfig.recipeSpawning
             .forEachIndexed { index, definition -> definition.registerRecipe(index) }
         Bukkit.getGlobalRegionScheduler().runAtFixedRate(
@@ -160,6 +160,8 @@ class BreweryRecipes : JavaPlugin() {
     }
 
     fun reload() {
+        val oldBookRecipe = recipesConfig.book.craftingRecipe
+        val oldSpawnDefinitions = spawnConfig.recipeSpawning
         brewingIntegration.reload()
         recipesConfig = readConfig()
         guiConfig = readGuiConfig()
@@ -171,8 +173,12 @@ class BreweryRecipes : JavaPlugin() {
         }
         recipeGuiItemCache.clearGlobal()
         RecipeViewLoreWriter.bumpVersion()
-        recipesConfig.book.craftingRecipe.register(recipesConfig.book.item.generateItem(), "breweryrecipes_book")
+        recipesConfig.book.craftingRecipe.register("recipes_book", BookUtil.createBook(), oldBookRecipe)
         spawnConfig.recipeSpawning
-            .forEachIndexed { index, definition -> definition.registerRecipe(index) }
+            .forEachIndexed { index, definition ->
+                definition.registerRecipe(index, oldSpawnDefinitions.firstOrNull { oldDefinition ->
+                    definition.recipeWhitelist == oldDefinition.recipeWhitelist && definition.recipeBlacklist == oldDefinition.recipeBlacklist
+                })
+            }
     }
 }

--- a/src/main/kotlin/dev/jsinco/recipes/configuration/CraftingDefinition.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/configuration/CraftingDefinition.kt
@@ -28,8 +28,10 @@ class CraftingDefinition : OkaeriConfig() {
     @CustomKey("ingredient-map")
     var ingredientMap: Map<String, Material> = mapOf("A" to Material.PAPER, "B" to Material.BOOK)
 
-    fun register(item: ItemStack, keyValue: String) {
+    fun register(keyValue: String, item: ItemStack, oldRecipe: CraftingDefinition? = null) {
         val recipeKey = key(keyValue)
+        // Can't compare Bukkit recipes directly as they don't implement equals()
+        if (this == oldRecipe && item == Bukkit.getRecipe(recipeKey)?.result) return
         Bukkit.removeRecipe(recipeKey)
         if (!this.enabled) return
         if (this.shaped) {
@@ -54,4 +56,27 @@ class CraftingDefinition : OkaeriConfig() {
             Logger.log("Added a shapeless recipe with key $keyValue")
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CraftingDefinition) return false
+
+        if (enabled != other.enabled) return false
+        if (shaped != other.shaped) return false
+        if (ingredients != other.ingredients) return false
+        if (shape != other.shape) return false
+        if (ingredientMap != other.ingredientMap) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = enabled.hashCode()
+        result = 31 * result + shaped.hashCode()
+        result = 31 * result + ingredients.hashCode()
+        result = 31 * result + shape.hashCode()
+        result = 31 * result + ingredientMap.hashCode()
+        return result
+    }
+
 }

--- a/src/main/kotlin/dev/jsinco/recipes/configuration/spawning/SpawnDefinition.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/configuration/spawning/SpawnDefinition.kt
@@ -7,6 +7,7 @@ import dev.jsinco.recipes.recipe.BreweryRecipe
 import dev.jsinco.recipes.recipe.flaws.creation.RecipeViewCreator
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
+import kotlin.random.Random
 
 data class SpawnDefinition(
     val enabled: Boolean? = null,
@@ -47,22 +48,24 @@ data class SpawnDefinition(
             .filter { recipeBlacklist.isNullOrEmpty() || !recipeBlacklist.contains(it.identifier) }
     }
 
-    private fun lootItem(breweryRecipe: BreweryRecipe): ItemStack {
+    private fun lootItem(breweryRecipe: BreweryRecipe, random: Random = Random.Default): ItemStack {
         val itemBase = itemOverride?.generateItem() ?: ItemType.PAPER.createItemStack()
         if (flawless) {
             return breweryRecipe.lootItem(itemBase)
         }
         if (flaws.isNullOrEmpty()) {
-            return breweryRecipe.lootItem(itemBase, RecipeViewCreator.Type.entries.toTypedArray().random())
+            return breweryRecipe.lootItem(itemBase, RecipeViewCreator.Type.entries.random(random))
         }
-        return breweryRecipe.lootItem(itemBase, flaws.random())
+        return breweryRecipe.lootItem(itemBase, flaws.random(random))
     }
 
     fun registerRecipe(index: Int) {
         val applicableRecipes = applicableRecipes()
         if (applicableRecipes.isEmpty()) return
+        val recipe = applicableRecipes.first()
+        val random = Random(recipe.recipeKey().hashCode().toLong()) // ensure crafting recipes are deterministic across reloads
         triggers?.craftingTrigger?.craftingDefinition?.register(
-            lootItem(applicableRecipes.random()),
+            lootItem(recipe, random),
             "spawning/index_$index"
         )
     }

--- a/src/main/kotlin/dev/jsinco/recipes/configuration/spawning/SpawnDefinition.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/configuration/spawning/SpawnDefinition.kt
@@ -59,14 +59,15 @@ data class SpawnDefinition(
         return breweryRecipe.lootItem(itemBase, flaws.random(random))
     }
 
-    fun registerRecipe(index: Int) {
+    fun registerRecipe(index: Int, old: SpawnDefinition? = null) {
         val applicableRecipes = applicableRecipes()
         if (applicableRecipes.isEmpty()) return
         val recipe = applicableRecipes.first()
         val random = Random(recipe.recipeKey().hashCode().toLong()) // ensure crafting recipes are deterministic across reloads
         triggers?.craftingTrigger?.craftingDefinition?.register(
+            "spawning/index_$index",
             lootItem(recipe, random),
-            "spawning/index_$index"
+            old?.triggers?.craftingTrigger?.craftingDefinition
         )
     }
 }


### PR DESCRIPTION
- The plugin will only un-register and re-register a crafting recipe on reload if the recipe has changed. This prevents unnecessary "recipe unlock" toast pop-ups, especially if the Vanilla Tweaks "Unlock All Recipes" datapack is installed.
- Crafting triggers no longer randomize the output after each reload.